### PR TITLE
Fix action keys in browser

### DIFF
--- a/src/main/java/com/cinemamod/fabric/cef/CefBrowserCinema.java
+++ b/src/main/java/com/cinemamod/fabric/cef/CefBrowserCinema.java
@@ -26,23 +26,25 @@ public class CefBrowserCinema extends CefBrowserOsr {
         renderer.onPaint(buffer, width, height);
     }
 
-    public void sendKeyPress(int keyCode, int modifiers) {
-        KeyEvent keyEvent = new KeyEvent(dummyComponent,
+    public void sendKeyPress(int keyCode, int modifiers, long scanCode) {
+        CefBrowserKeyEvent keyEvent = new CefBrowserKeyEvent(dummyComponent,
                 KeyEvent.KEY_PRESSED,
                 System.currentTimeMillis(),
                 modifiers,
                 keyCode,
-                KeyEvent.CHAR_UNDEFINED);
+                KeyEvent.CHAR_UNDEFINED,
+                scanCode);
         sendKeyEvent(keyEvent);
     }
 
-    public void sendKeyRelease(int keyCode, int modifiers) {
-        KeyEvent keyEvent = new KeyEvent(dummyComponent,
+    public void sendKeyRelease(int keyCode, int modifiers, long scanCode) {
+        CefBrowserKeyEvent keyEvent = new CefBrowserKeyEvent(dummyComponent,
                 KeyEvent.KEY_RELEASED,
                 System.currentTimeMillis(),
                 modifiers,
                 keyCode,
-                KeyEvent.CHAR_UNDEFINED);
+                KeyEvent.CHAR_UNDEFINED,
+                scanCode);
         sendKeyEvent(keyEvent);
     }
 

--- a/src/main/java/com/cinemamod/fabric/cef/CefBrowserKeyEvent.java
+++ b/src/main/java/com/cinemamod/fabric/cef/CefBrowserKeyEvent.java
@@ -1,0 +1,19 @@
+package com.cinemamod.fabric.cef;
+
+import java.awt.Component;
+import java.awt.event.KeyEvent;
+
+public class CefBrowserKeyEvent extends KeyEvent {
+
+    private static final long serialVersionUID = 1L;
+    private long scancode = 0;
+
+    public CefBrowserKeyEvent(Component source, int id, long when, int modifiers, int keyCode, char keyChar, int keyLocation) {
+        super(source, id, when, modifiers, keyCode, keyChar, keyLocation);
+    }
+
+    public CefBrowserKeyEvent(Component source, int id, long when, int modifiers, int keyCode, char keyChar, long scanCode) {
+        super(source, id, when, modifiers, keyCode, keyChar);
+        this.scancode = scanCode;
+    }
+}

--- a/src/main/java/com/cinemamod/fabric/gui/VideoRequestBrowser.java
+++ b/src/main/java/com/cinemamod/fabric/gui/VideoRequestBrowser.java
@@ -15,9 +15,10 @@ import net.minecraft.client.render.*;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.Text;
-import org.lwjgl.glfw.GLFW;
 
-import static java.awt.event.KeyEvent.VK_ENTER;
+import java.awt.event.KeyEvent;
+
+import org.lwjgl.glfw.GLFW;
 
 public class VideoRequestBrowser extends Screen {
 
@@ -117,33 +118,49 @@ public class VideoRequestBrowser extends Screen {
     private static int remapKeyCode(int keyCode) {
         switch (keyCode) {
             case GLFW.GLFW_KEY_BACKSPACE:
-                return 0x08;
+                return KeyEvent.VK_BACK_SPACE;
             case GLFW.GLFW_KEY_DELETE:
-                return 0x2E;
+                return KeyEvent.VK_DELETE;
             case GLFW.GLFW_KEY_DOWN:
-                return 0x28;
+                return KeyEvent.VK_DOWN;
             case GLFW.GLFW_KEY_ENTER:
-                return VK_ENTER;
+                return KeyEvent.VK_ENTER;
             case GLFW.GLFW_KEY_ESCAPE:
-                return 0x1B;
+                return KeyEvent.VK_ESCAPE;
             case GLFW.GLFW_KEY_LEFT:
-                return 0x25;
+                return KeyEvent.VK_LEFT;
             case GLFW.GLFW_KEY_RIGHT:
-                return 0x27;
+                return KeyEvent.VK_RIGHT;
             case GLFW.GLFW_KEY_TAB:
-                return 0x09;
+                return KeyEvent.VK_TAB;
             case GLFW.GLFW_KEY_UP:
-                return 0x26;
+                return KeyEvent.VK_UP;
             case GLFW.GLFW_KEY_PAGE_UP:
-                return 0x21;
+                return KeyEvent.VK_PAGE_UP;
             case GLFW.GLFW_KEY_PAGE_DOWN:
-                return 0x22;
+                return KeyEvent.VK_PAGE_DOWN;
             case GLFW.GLFW_KEY_END:
-                return 0x23;
+                return KeyEvent.VK_END;
             case GLFW.GLFW_KEY_HOME:
-                return 0x24;
+                return KeyEvent.VK_HOME;
         }
         return -1;
+    }
+
+    private static int remapScanCode(int scanCode) {
+        switch(scanCode) {
+            case 327: return 0x47; // HOME
+            case 328: return 0x48; // UP
+            case 329: return 0x49; // PGUP
+            case 331: return 0x4B; // LEFT
+            case 333: return 0x4D; // RIGHT
+            case 335: return 0x4F; // END
+            case 336: return 0x50; // DOWN
+            case 337: return 0x51; // PGDOWN
+            case 338: return 0x52; // PGDOWN
+            case 339: return 0x53; // DEL
+        }
+        return scanCode;
     }
 
     @Override
@@ -169,7 +186,7 @@ public class VideoRequestBrowser extends Screen {
 
         int remap = remapKeyCode(keyCode);
         if (remap != -1) {
-            browser.sendKeyPress(remap, modifiers);
+            browser.sendKeyPress(remap, modifiers, remapScanCode(scanCode));
         }
 
         return true;
@@ -191,10 +208,10 @@ public class VideoRequestBrowser extends Screen {
 
         int remap = remapKeyCode(keyCode);
         if (remap != -1) {
-            if (remap == VK_ENTER) {
+            if (remap == KeyEvent.VK_ENTER) {
                 browser.sendKeyTyped((char)13, 0);
             }
-            browser.sendKeyRelease(remap, modifiers);
+            browser.sendKeyRelease(remap, modifiers, remapScanCode(scanCode));
         }
 
         return true;


### PR DESCRIPTION
By sending a custom KeyEvent instead of the java.awt one, we can send the scancode too, which is needed on Windows for action keys (tab, backspace, arrows, home, end, etc.) to work.
Changing the key code mapping to the VK_* constants should also fix this on Linux and macOS.